### PR TITLE
Mail more exceptions

### DIFF
--- a/sources/dspace-api/src/main/java/cz/cuni/mff/ufal/Logger.java
+++ b/sources/dspace-api/src/main/java/cz/cuni/mff/ufal/Logger.java
@@ -28,13 +28,12 @@ public class Logger {
     }
     
     
-} // class
 
 
 //
 //
 //
-class own_logger extends org.apache.log4j.Logger
+public static class own_logger extends org.apache.log4j.Logger
 {
     // variables
     org.apache.log4j.Logger impl_;
@@ -59,7 +58,7 @@ class own_logger extends org.apache.log4j.Logger
     }
     
     //
-    void send_error(Throwable t) {
+   public void send_error(Throwable t) {
         send_error(ExceptionUtils.getStackTrace(t));
     }
 
@@ -266,5 +265,4 @@ class own_logger extends org.apache.log4j.Logger
     }
     
 } // class 
-
-
+} // class

--- a/sources/dspace-xmlui/dspace-xmlui-api/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/cocoon/generation/EmailExceptionGenerator.java
+++ b/sources/dspace-xmlui/dspace-xmlui-api/src/main/java/cz/cuni/mff/ufal/dspace/app/xmlui/cocoon/generation/EmailExceptionGenerator.java
@@ -1,0 +1,25 @@
+package cz.cuni.mff.ufal.dspace.app.xmlui.cocoon.generation;
+
+import java.io.IOException;
+
+import org.apache.cocoon.ProcessingException;
+import org.apache.cocoon.environment.ObjectModelHelper;
+import org.apache.cocoon.generation.ExceptionGenerator;
+import org.xml.sax.SAXException;
+
+import cz.cuni.mff.ufal.Logger;
+
+public class EmailExceptionGenerator extends ExceptionGenerator {
+	private static final Logger.own_logger log = (Logger.own_logger) Logger.getLogger(EmailExceptionGenerator.class);
+
+	@Override
+    public void generate() throws IOException, SAXException, ProcessingException {
+		super.generate();
+		if(this.parameters.getParameterAsBoolean("send_email", false)){
+			Throwable t = ObjectModelHelper.getThrowable(objectModel);
+			log.send_error(t);
+		}
+    }
+	
+
+}

--- a/sources/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/sitemap.xmap
+++ b/sources/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/sitemap.xmap
@@ -20,7 +20,7 @@
                         <map:generator name="DSpaceOREGenerator" src="org.dspace.app.xmlui.cocoon.DSpaceOREGenerator"/>
                         <map:generator name="OpenSearchGenerator" src="org.dspace.app.xmlui.cocoon.OpenSearchGenerator"/>
                         <map:generator name="notifying" src="org.apache.cocoon.sitemap.NotifyingGenerator"/>
-                        <map:generator name="exception" src="org.apache.cocoon.generation.ExceptionGenerator"/>
+                        <map:generator name="exception" src="cz.cuni.mff.ufal.dspace.app.xmlui.cocoon.generation.ExceptionGenerator"/>
                         <map:generator name="AJAXMenuGenerator"
                              src="org.dspace.app.xmlui.cocoon.AJAXMenuGenerator"/>
                 </map:generators>
@@ -681,7 +681,9 @@
                                 </map:when>
 
                                 <map:otherwise>
-                                        <map:generate type="exception"/>
+                                        <map:generate type="exception">
+                                        	<map:parameter name="send_email" value="true"/>
+                                        </map:generate>
                                         <map:transform src="exception2html.xslt">
                                                 <map:parameter name="contextPath" value="{request:contextPath}"/>
                                         </map:transform>

--- a/sources/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/sitemap.xmap
+++ b/sources/dspace-xmlui/dspace-xmlui-webapp/src/main/webapp/sitemap.xmap
@@ -20,7 +20,7 @@
                         <map:generator name="DSpaceOREGenerator" src="org.dspace.app.xmlui.cocoon.DSpaceOREGenerator"/>
                         <map:generator name="OpenSearchGenerator" src="org.dspace.app.xmlui.cocoon.OpenSearchGenerator"/>
                         <map:generator name="notifying" src="org.apache.cocoon.sitemap.NotifyingGenerator"/>
-                        <map:generator name="exception" src="cz.cuni.mff.ufal.dspace.app.xmlui.cocoon.generation.ExceptionGenerator"/>
+                        <map:generator name="exception" src="cz.cuni.mff.ufal.dspace.app.xmlui.cocoon.generation.EmailExceptionGenerator"/>
                         <map:generator name="AJAXMenuGenerator"
                              src="org.dspace.app.xmlui.cocoon.AJAXMenuGenerator"/>
                 </map:generators>


### PR DESCRIPTION
Every time user is displayed an exception/error page we should receive an email. not-found, file-not-found  and invalid-continuation won't be sent